### PR TITLE
Address review issues across UI, Stan models, and API

### DIFF
--- a/R/audit.R
+++ b/R/audit.R
@@ -85,7 +85,7 @@ audit_event <- function(action, payload = list(), session = shiny::getDefaultRea
   on.exit(try(DBI::dbDisconnect(con), silent = TRUE))
   prev <- try(DBI::dbGetQuery(con, "SELECT hash FROM audit_log ORDER BY id DESC LIMIT 1"), silent = TRUE)
   prev_hash <- if (!inherits(prev, "try-error") && nrow(prev) > 0) prev$hash[1] else "GENESIS"
-  ts <- format(Sys.time(), tz = "UTC", usetz = True)
+  ts <- format(Sys.time(), tz = "UTC", usetz = TRUE)
   payload_json <- jsonlite::toJSON(entry$payload, auto_unbox = TRUE, null = "null")
   chain_input <- paste(prev_hash, ts, entry$actor, entry$action, payload_json, sep = "|")
   h <- digest::digest(chain_input, algo = "sha256")

--- a/R/backend_bayes.R
+++ b/R/backend_bayes.R
@@ -35,7 +35,7 @@ neg_log_post_map <- function(par_log, obs, regimen, priors, model_type, error_mo
   -(ll + lp)
 }
 
-run_fit_laplace <- function(obs, regimen, priors, model_type, error_model, covariates, estimate_sigma, sigma_init, blq_lloq = NA_real_, is_blq = NULL) {
+run_fit_laplace <- function(obs, regimen, priors, model_type, error_model, covariates, estimate_sigma, sigma_init, blq_lloq = NA_real_, is_blq = NULL, creatinine_data = NULL) {
   validate_inputs_units(regimen, obs)
   th0 <- log(priors$theta) # Start bei prior-Mean
   sigma_add <- sigma_init[["add"]]; sigma_prop <- sigma_init[["prop"]]

--- a/api/plumber_auth.R
+++ b/api/plumber_auth.R
@@ -12,7 +12,8 @@
 function(username, password, res) {
   ok <- try(auth_check(username, password), silent = TRUE)
   if (!isTRUE(ok)) { res$status <- 401; return(list(error="invalid_credentials")) }
-  secret <- Sys.getenv("TDMX_JWT_SECRET", "CHANGE_ME")
+  secret <- Sys.getenv("TDMX_JWT_SECRET", "")
+  if (!nzchar(secret)) { res$status <- 500; return(list(error="jwt_secret_not_set")) }
   if (!requireNamespace("jose", quietly = TRUE)) { res$status <- 500; return(list(error="missing_jose_package")) }
   claims <- list(sub = username, iat = as.numeric(Sys.time()), exp = as.numeric(Sys.time()) + 3600)
   token <- jose::jwt_encode_hmac(claims, secret = charToRaw(secret))
@@ -30,13 +31,14 @@ function(req, res) {
   parts <- strsplit(auth, " ")[[1]]
   if (length(parts) != 2 || tolower(parts[1]) != "bearer") { res$status <- 401; return(list(error = "invalid_authorization_header")) }
   token <- parts[2]
-  secret <- Sys.getenv("TDMX_JWT_SECRET", "CHANGE_ME")
+  secret <- Sys.getenv("TDMX_JWT_SECRET", "")
+  if (!nzchar(secret)) { res$status <- 500; return(list(error="jwt_secret_not_set")) }
   if (!requireNamespace("jose", quietly = TRUE)) { res$status <- 500; return(list(error="missing_jose_package")) }
   ok <- TRUE
   claims <- NULL
   tryCatch({
-    claims <<- jose::jwt_decode_hmac(token, secret = charToRaw(secret))
-  }, error = function(e) ok <<- FALSE)
+    claims <- jose::jwt_decode_hmac(token, secret = charToRaw(secret))
+  }, error = function(e) ok <- FALSE)
   if (!ok) { res$status <- 401; return(list(error="invalid_token")) }
   # Attach user to request for handlers
   req$user <- claims$sub

--- a/app.R
+++ b/app.R
@@ -63,7 +63,9 @@ app_ui <- function() {
             uiOutput("drug_selector"),
             selectInput("model_type", "Modell", choices = c("1C","2C","3C","MM-1C","TMDD-QSS-1C"), selected = "1C"),
             selectInput("error_model", "Residualfehler", choices = c("additiv","proportional","kombiniert","t-additiv","t-proportional","mixture"), selected = "kombiniert"),
-            selectInput("backend", "Bayes-Backend", choices = c("Laplace (schnell)","Stan (voll Bayes)","Stan-ADVI (schnell)","JAGS (voll Bayes)"), 
+            selectInput("backend", "Bayes-Backend",
+                        choices = c("Laplace (schnell)","Stan (voll Bayes)","Stan-ADVI (schnell)","JAGS (voll Bayes)"),
+                        selected = "Laplace (schnell)"),
             conditionalPanel(
               condition = "input.backend && input.backend.indexOf('Stan') >= 0",
               hr(),
@@ -73,8 +75,7 @@ app_ui <- function() {
               numericInput("hmc_sampling", "Sampling-Iterationen", value = 1000, min = 100, step = 100),
               numericInput("hmc_adapt_delta", "adapt_delta", value = 0.9, min = 0.5, max = 0.999, step = 0.01),
               numericInput("hmc_max_treedepth", "max_treedepth", value = 12, min = 8, max = 15, step = 1)
-            )
-selected = "Laplace (schnell)"),
+            ),
             checkboxInput("use_cache", "Warm-Start/Cache aktivieren", value = TRUE),
             numericInput("stan_chains", "Stan Chains", value = 4, min = 1, step = 1),
             numericInput("stan_iter", "Stan Iter Sampling", value = 1000, min = 200, step = 100),

--- a/models/stan/pk_mm_onecpt_ode.stan
+++ b/models/stan/pk_mm_onecpt_ode.stan
@@ -89,15 +89,15 @@ model {
     if (error_model == 1) {
       s = sigma_add;
     } else if (error_model == 2) {
-      s = sigma_prop * pred[n];
+      s = sigma_prop * fabs(pred[n]);
     } else if (error_model == 3) {
-      s = sqrt(square(sigma_add) + square(sigma_prop * pred[n]));
+      s = sqrt(square(sigma_add) + square(sigma_prop * fabs(pred[n])));
     } else if (error_model == 4) { // t-add
       s = sigma_add;
     } else if (error_model == 5) { // t-prop
-      s = sigma_prop * pred[n];
+      s = sigma_prop * fabs(pred[n]);
     } else { // mixture uses normal components; s computed as prop error
-      s = sqrt(square(sigma_add) + square(sigma_prop * pred[n]));
+      s = sqrt(square(sigma_add) + square(sigma_prop * fabs(pred[n])));
     }
 
     if (is_blq[n] == 1) {

--- a/models/stan/pk_multicpt_ode.stan
+++ b/models/stan/pk_multicpt_ode.stan
@@ -107,7 +107,7 @@ model {
     } else if (error_model == 2) {
       s = fmax(1e-6, sigma_prop * fabs(pred[n]));
     } else if (error_model == 3) {
-      s = sqrt(fmax(1e-12, square(sigma_add) + square(sigma_prop * pred[n])));
+      s = sqrt(fmax(1e-12, square(sigma_add) + square(sigma_prop * fabs(pred[n]))));
     } else if (error_model == 4) { // t-add
       s = sigma_add;
     } else if (error_model == 5) { // t-prop


### PR DESCRIPTION
## Summary
- correct Shiny backend selector structure
- add missing creatinine_data argument to Laplace backend
- enforce JWT secret configuration and avoid global state
- guard Stan proportional error terms with fabs
- fix audit timestamp boolean

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897407efdec8329a73159a2ea39fd46